### PR TITLE
Hash bang fix

### DIFF
--- a/docbuilder.py
+++ b/docbuilder.py
@@ -63,18 +63,14 @@ def unicodeCompareChar(uniCode):
 
 def markdownWrite(stringLine, fileToWrite):
     outFile = open(fileToWrite, "a")
-    outFile.write("\n")
-    outFile.write(stringLine)
-    outFile.write("\n")
+    outFile.write(stringLine + "\n\n")
     outFile.close()
 
     
 def codeblockWrite(stringLine, fileToWrite):
     if stringLine != "hashBang":
         outFile = open(fileToWrite, "a")
-        outFile.write("\n```\n")
-        outFile.write(stringLine)
-        outFile.write("\n```\n")
+        outFile.write("\n```\n" + stringLine + "\n```\n")
         outFile.close()
 
     

--- a/docbuilder.py
+++ b/docbuilder.py
@@ -25,6 +25,10 @@ import sys
 def stringManage(lineInFile):
     global verboseActive
     stringUnstripped = lineInFile
+    if stringUnstripped[:3] == "#!/":
+        if verboseActive:
+            print("Found hashbang! Ignoring.")
+        stringUnstripped = "hashBang"
     if verboseActive:
         print("The current unstripped line is... " + stringUnstripped)
     stringStripped = stringUnstripped.strip()
@@ -66,11 +70,12 @@ def markdownWrite(stringLine, fileToWrite):
 
     
 def codeblockWrite(stringLine, fileToWrite):
-    outFile = open(fileToWrite, "a")
-    outFile.write("\n```\n")
-    outFile.write(stringLine)
-    outFile.write("\n```\n")
-    outFile.close()
+    if stringLine != "hashBang":
+        outFile = open(fileToWrite, "a")
+        outFile.write("\n```\n")
+        outFile.write(stringLine)
+        outFile.write("\n```\n")
+        outFile.close()
 
     
 def initFileOut(outFile):
@@ -88,7 +93,8 @@ def readFile(inputFile):
         firstChar = stringManage(lineRead)[2]
         compareChar = unicodeCompareChar(35)
         if firstChar == compareChar:
-            markdownWrite(stringStripped, outFile)
+            if stringUnstripped != "hashBang":
+                markdownWrite(stringStripped, outFile)
         else:
             if stringUnstripped != "":
                 codeblockWrite(stringUnstripped, outFile)

--- a/tests/test.py
+++ b/tests/test.py
@@ -103,7 +103,7 @@ class TestCodeFormat(unittest.TestCase):
         teardown()
         buildup()
         global lines
-        if lines[1] == "# This is a title.\n":
+        if lines[0] == "# This is a title.\n":
             print("Titles compile correctly to Markdown.")
             pass
         else:
@@ -118,7 +118,7 @@ class TestCodeFormat(unittest.TestCase):
         teardown()
         buildup()
         global lines
-        if lines[3] == "This is a comment.\n":
+        if lines[2] == "This is a comment.\n":
             print("Comments compile correctly to Markdown.")
             pass
         else:
@@ -132,7 +132,7 @@ class TestCodeFormat(unittest.TestCase):
         teardown()
         buildup()
         global lines
-        if lines[5] == "* This is a bullet point.\n":
+        if lines[4] == "* This is a bullet point.\n":
             print("Bullet points compile correctly to Markdown.")
             pass
         else:
@@ -146,7 +146,7 @@ class TestCodeFormat(unittest.TestCase):
         teardown()
         buildup()
         global lines
-        if lines[7] == "*This* is an italic word.\n":
+        if lines[6] == "*This* is an italic word.\n":
             print("Italics compile correctly to Markdown.")
             pass
         else:
@@ -160,7 +160,7 @@ class TestCodeFormat(unittest.TestCase):
         teardown()
         buildup()
         global lines
-        if lines[9] == "**This** is a bold word.\n":
+        if lines[8] == "**This** is a bold word.\n":
             print("Bold compiled correctly to Markdown.")
             pass
         else:
@@ -174,13 +174,13 @@ class TestCodeFormat(unittest.TestCase):
         teardown()
         buildup()
         global lines
-        if lines[11] == "***This*** is an italic and bold word.\n":
+        if lines[10] == "***This*** is an italic and bold word.\n":
             print("Both bold and italic compiles correctly to Markdown.")
             pass
         else:
             print("Both bold and italic phrases failed to compile to Markdown.")
             print("Expected: ***This*** is an italic and bold word.\n")
-            print("Received: " + lines[11])
+            print("Received: " + lines[10])
             assert False
     
     def test_markdown_codeblocks(self):
@@ -206,7 +206,7 @@ class TestCodeFormat(unittest.TestCase):
         else:
             print("Code block failed to compile to Markdown.")
             print("Expected: ```\n")
-            print("Received: " + lines[13])
+            print("Received: " + lines[12])
             assert False
 
     def test_markdown_indented_code_block(self):


### PR DESCRIPTION
To ensure the UNIX-style "hash bang" doesn't appear in generated documentation.

To fix #20.
